### PR TITLE
Fix Jellyfin permissions

### DIFF
--- a/inventory/host_vars/memory-alpha/apps.yml
+++ b/inventory/host_vars/memory-alpha/apps.yml
@@ -13,6 +13,8 @@ apps:
         mode: "0775"
       - path: /data/apps/jellyfin
         owner: jellyfin
+        group: bfrank
+        mode: "0750"
   plex:
     system_account: true
     system_uid: 1600

--- a/playbooks/files/apps/jellyfin/docker-compose.yml
+++ b/playbooks/files/apps/jellyfin/docker-compose.yml
@@ -3,11 +3,13 @@
 services:
   jellyfin:
     container_name: jellyfin
+    devices:
+      - /dev/dri:/dev/dri
     environment:
       - JELLYFIN_PublishedServerUrl="${FQDN}"
       - HOSTNAME="docker-jellyfin"
-      - PUID="${UID}"
-      - PGID="${GID}"
+      - PUID=${UID}
+      - PGID=1000
       - TZ="America/New_York"
     hostname: jellyfin
     image: lscr.io/linuxserver/jellyfin:latest

--- a/playbooks/templates/apps/jellyfin.env.j2
+++ b/playbooks/templates/apps/jellyfin.env.j2
@@ -1,3 +1,2 @@
 FQDN={{ apps['jellyfin']['subdomain'] }}.{{ fqdn['domain'] }}.{{ fqdn['tld'] }}
 UID={{ apps['jellyfin']['system_uid'] }}
-GID={{ ansible_facts['getent_group']['staff'][1] }}


### PR DESCRIPTION
Corrects permissions on volume mounts to match what's running in the container.